### PR TITLE
Fix secchidepth band alignment and replace Arst PP with Lee model

### DIFF
--- a/parameters/alplakes_s3.ini
+++ b/parameters/alplakes_s3.ini
@@ -34,11 +34,10 @@ processor=POLYMER
 processor=POLYMER
 
 [PRIMARYPRODUCTION]
-chl_parameter=CHL
 chl_processor=OC3
 chl_bandname=chla
 kd_processor=SECCHIDEPTH
-kd_bandname=Zsd_lee
+kd_bandname=Kd490
 
 [GEOTIFF]
 overwrite=true

--- a/parameters/test_S2_processors.ini
+++ b/parameters/test_S2_processors.ini
@@ -71,11 +71,10 @@ validexpression=pixel_classif_flags.IDEPIX_CLEAR_LAND and !pixel_classif_flags.I
 processor=C2RCC
 
 [PRIMARYPRODUCTION]
-chl_parameter=CHL
 chl_processor=OC3
 chl_bandname=chla
 kd_processor=SECCHIDEPTH
-kd_bandname=Zsd_lee
+kd_bandname=Kd490
 
 [SECCHIDEPTH]
 # Specify from which reflectance product Secchi depth is derived

--- a/parameters/test_S3_processors.ini
+++ b/parameters/test_S3_processors.ini
@@ -76,11 +76,10 @@ processor=POLYMER
 processor=POLYMER
 
 [PRIMARYPRODUCTION]
-chl_parameter=CHL
 chl_processor=OC3
 chl_bandname=chla
 kd_processor=SECCHIDEPTH
-kd_bandname=Zsd_lee
+kd_bandname=Kd490
 
 [SECCHIDEPTH]
 # Specify from which reflectance product Secchi depth is derived

--- a/processors/primaryproduction/lee_pp.py
+++ b/processors/primaryproduction/lee_pp.py
@@ -1,0 +1,100 @@
+"""
+Lee primary production model for sencast.
+Spectrally resolved (400-700 nm, 10 nm) with Staehr & Markager 2004 aph.
+"""
+
+import numpy as np
+from scipy.integrate import trapezoid
+
+WV = np.arange(400, 710, 10)
+N_DEPTH = 101
+
+# Staehr & Markager 2004 (31 bands, 400-700 nm at 10 nm)
+A_SM = np.array([
+    0.033, 0.03840468, 0.045, 0.05008251, 0.053, 0.0509849,
+    0.048, 0.04547831, 0.042, 0.03696949, 0.031, 0.02498517,
+    0.019, 0.01539597, 0.013, 0.01045871, 0.009, 0.00811671,
+    0.007, 0.00797494, 0.008, 0.00802645, 0.009, 0.00949961,
+    0.01, 0.01138279, 0.014, 0.02161268, 0.023, 0.0129098,
+    0.005,
+])
+
+B_SM = np.array([
+    0.233, 0.24552237, 0.259, 0.27323491, 0.281, 0.29265144,
+    0.299, 0.29762277, 0.307, 0.29821063, 0.258, 0.21450849,
+    0.172, 0.13739559, 0.111, 0.09845876, 0.103, 0.11762342,
+    0.134, 0.1619905, 0.184, 0.17937802, 0.164, 0.17907438,
+    0.193, 0.211646, 0.219, 0.19884796, 0.159, 0.11693024,
+    0.137,
+])
+
+# Reference PAR spectrum (31 bands, 400-700 nm at 10 nm)
+PAR_FRACTION = np.array([
+    0.00227, 0.00218, 0.00239, 0.00189, 0.00297, 0.00348, 0.00345, 0.00344,
+    0.00373, 0.00377, 0.00362, 0.00364, 0.00360, 0.00367, 0.00354, 0.00368,
+    0.00354, 0.00357, 0.00363, 0.00332, 0.00358, 0.00357, 0.00359, 0.00340,
+    0.00350, 0.00332, 0.00342, 0.00347, 0.00342, 0.00290, 0.00314,
+])
+
+PHI_MAX = 0.06
+SCALAR_CORR = 1.4
+UMOL_S_TO_MOL_H = 3600 * 1e-6
+
+
+def _kd490_to_kdpar(kd490):
+    """Morel (2007) conversion from Kd(490) to Kd(PAR)."""
+    return 0.0864 + 0.884 * kd490 - 0.00137 / kd490
+
+
+def _quantum_yield(E_mol_h):
+    """Lee quantum yield. E in mol/m2/h."""
+    E_mol_h = np.maximum(E_mol_h, 1e-6)
+    return PHI_MAX * (0.4 * np.exp(-0.24 * E_mol_h)) / (0.4 + E_mol_h)
+
+
+def lee_pp(chl, kd490, par_hourly):
+    """Compute daily primary production for all pixels.
+
+    Takes Chl [mg/m3], Kd490 [m-1], and hourly PAR [umol/m2/s].
+    Returns PP [mg C/m2/day] and KdPAR [m-1].
+    """
+    chl = np.asarray(chl, dtype=np.float64)
+    kd490 = np.asarray(kd490, dtype=np.float64)
+    N = chl.shape[0]
+
+    npp = np.full(N, np.nan)
+    kdpar = np.full(N, np.nan)
+
+    valid = np.isfinite(chl) & np.isfinite(kd490) & (chl > 0) & (kd490 > 0)
+    if not np.any(valid):
+        return npp, kdpar
+
+    c = chl[valid]
+    k = kd490[valid]
+    M = c.shape[0]
+
+    aph_spec = A_SM[None, :] * (c[:, None] ** (-B_SM[None, :])) * c[:, None]
+    kp = _kd490_to_kdpar(k)
+
+    z_max = np.minimum(4.6 / kp, 200.0)
+    zfrac = np.linspace(0, 1, N_DEPTH)
+    z_grid = z_max[:, None] * zfrac[None, :]
+    atten = np.exp(-kp[:, None, None] * z_grid[:, :, None]) * PAR_FRACTION[None, None, :]
+
+    e_weight = trapezoid(atten, WV, axis=2) * SCALAR_CORR * UMOL_S_TO_MOL_H
+    ap_weight = trapezoid(atten * aph_spec[:, None, :], WV, axis=2) * SCALAR_CORR * UMOL_S_TO_MOL_H
+
+    npp_valid = np.zeros(M)
+    for par_surface in par_hourly:
+        if par_surface <= 0 or not np.isfinite(par_surface):
+            continue
+        e_scalar = par_surface * e_weight
+        ap = par_surface * ap_weight
+        f = _quantum_yield(e_scalar)
+        pp_z = 12000 * f * ap
+        npp_valid += trapezoid(pp_z, z_grid, axis=1)
+
+    npp[valid] = npp_valid
+    kdpar[valid] = kp
+
+    return npp, kdpar

--- a/processors/primaryproduction/primaryproduction.py
+++ b/processors/primaryproduction/primaryproduction.py
@@ -2,19 +2,21 @@
 # -*- coding: utf-8 -*-
 
 """
-The Primary Production processor is an implementation of `T.Soomets et al. 2019 <https://core.ac.uk/reader/211997910>`_
-in order to derive primary production from Satellite images.
+Primary Production processor using the Lee et al. quantum yield model
+with ERA5 hourly PAR.
 """
 
 import os
 import numpy as np
-from scipy.integrate import trapezoid
+import xarray as xr
 
+import cdsapi
 from netCDF4 import Dataset
 from utils.auxil import log
 from utils.product_fun import copy_nc, get_band_names_from_nc, get_name_width_height_from_nc, \
-    get_satellite_name_from_product_name, get_valid_pe_from_nc, write_pixels_to_nc, create_band, read_pixels_from_nc, \
+    get_valid_pe_from_nc, write_pixels_to_nc, create_band, read_pixels_from_nc, \
     get_sensing_date_from_product_name, copy_band
+from processors.primaryproduction.lee_pp import lee_pp
 
 # key of the params section for this adapter
 PARAMS_SECTION = "PRIMARYPRODUCTION"
@@ -22,6 +24,37 @@ PARAMS_SECTION = "PRIMARYPRODUCTION"
 OUT_DIR = 'L2PP'
 # A pattern for the name of the file to which the output product will be saved (completed with product name)
 OUT_FILENAME = 'L2PP_{}'
+
+# ERA5 ssrd (J/m² per hour) to surface PAR (µmol/m²/s)
+# ssrd/3600 → W/m², ×0.45 PAR fraction, ×4.57 W/m²→µmol/m²/s, ×0.95 surface transmission
+SSRD_TO_PAR = (1.0 / 3600) * 0.45 * 4.57 * 0.95
+
+
+def read_era5_par(era5_dir, date, lat, lon):
+    """Read 24h of ERA5 ssrd and convert to hourly surface PAR.
+    Downloads from CDS if not cached.
+    """
+    year, month, day = date[:4], date[4:6], date[6:8]
+    target = os.path.join(era5_dir, year, month, day, f'era5_ssrd_{date}.nc')
+    if not os.path.exists(target):
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        client = cdsapi.Client()
+        client.retrieve(
+            'reanalysis-era5-single-levels',
+            {
+                'product_type': 'reanalysis',
+                'variable': 'surface_solar_radiation_downwards',
+                'year': year,
+                'month': month,
+                'day': day,
+                'time': [f'{h:02d}:00' for h in range(24)],
+                'format': 'netcdf',
+            },
+            target)
+    ds = xr.open_dataset(target)
+    ssrd = ds.ssrd.sel(latitude=lat, longitude=lon, method='nearest').values.flatten()
+    ds.close()
+    return ssrd * SSRD_TO_PAR
 
 
 def process(env, params, l1product_path, l2product_files, out_path):
@@ -77,12 +110,6 @@ def process(env, params, l1product_path, l2product_files, out_path):
             return output_file
     os.makedirs(product_dir, exist_ok=True)
 
-    log(env["General"]["log"], "Collecting depths", indent=1)
-    zvals = np.array([0, 1, 2, 3.5, 5, 7.5, 10, 15, 20, 30])
-    if "depths" in params[PARAMS_SECTION]:
-        zvals = np.array(params[PARAMS_SECTION]["depths"])
-    zvals_fine = np.linspace(np.min(zvals), np.max(zvals), 100)  # Fine spaced depths for integration
-
     with Dataset(product_path) as chl_src, Dataset(kd_product_path) as kd_src, Dataset(output_file, mode='w') as dst:
         log(env["General"]["log"], "Reading Chlorophyll values from {}".format(product_path), indent=1)
         chl_band_names = get_band_names_from_nc(chl_src)
@@ -92,10 +119,6 @@ def process(env, params, l1product_path, l2product_files, out_path):
         chl_data = np.zeros(width * height, np.float32)
         read_pixels_from_nc(chl_src, chl_bandname, 0, 0, width, height, chl_data)
         chl_valid_pixel_expression = get_valid_pe_from_nc(chl_src, chl_bandname)
-
-        if "chl_parameter" in params[PARAMS_SECTION] and params[PARAMS_SECTION]["chl_parameter"] == "PH":
-            log(env["General"]["log"], "Convert from PH to CHL", indent=1)
-            chl_data = PhytoplanktonToChlorophyll(chl_data)
 
         log(env["General"]["log"], "Reading kd values from {}".format(kd_product_path), indent=1)
         kd_band_names = get_band_names_from_nc(kd_src)
@@ -118,97 +141,28 @@ def process(env, params, l1product_path, l2product_files, out_path):
                 copy_band(kd_src, dst, band_name)
         valid_pixel_expression = None
         if chl_valid_pixel_expression is not None and kd_valid_pixel_expression is not None and chl_valid_pixel_expression != kd_valid_pixel_expression:
-            valid_pixel_expression = '({}) and (){}'.format(chl_valid_pixel_expression, kd_valid_pixel_expression)
+            valid_pixel_expression = '({}) and ({})'.format(chl_valid_pixel_expression, kd_valid_pixel_expression)
         elif chl_valid_pixel_expression is not None:
             valid_pixel_expression = chl_valid_pixel_expression
         elif kd_valid_pixel_expression is not None:
             valid_pixel_expression = kd_valid_pixel_expression
 
-        log(env["General"]["log"], "Looking up PAR values.", indent=1)
         date = get_sensing_date_from_product_name(product_name)
-        month = datetomonth(date)
-        qpar0 = qpar0_lookup(month, chl_data)
 
-        log(env["General"]["log"], "Calculating KdMorel.", indent=1)
-        KdMorel = 0.0864 + 0.884 * kd_data - 0.00137/kd_data
+        log(env["General"]["log"], "Reading ERA5 hourly PAR.", indent=1)
+        lat_mean = float(np.nanmean(kd_src.variables['lat'][:]))
+        lon_mean = float(np.nanmean(kd_src.variables['lon'][:]))
+        par_hourly = read_era5_par(env['CDS']['anc_path'], date, lat_mean, lon_mean)
 
-        log(env["General"]["log"], "Calculating Primary Production.", indent=1)
-        pp_data = pp_trapezoidal_numerical_integration(zvals_fine, qpar0, chl_data, KdMorel)
+        log(env["General"]["log"], "Calculating Lee Primary Production.", indent=1)
+        pp_data, kdpar_data = lee_pp(chl_data, kd_data, par_hourly)
+        pp_data = pp_data.astype(np.float32)
+        kdpar_data = kdpar_data.astype(np.float32)
 
         log(env["General"]["log"], "Writing new bands to file.", indent=1)
-        create_band(dst, 'pp_integral', 'mg C m^-2 h^-1', valid_pixel_expression)
+        create_band(dst, 'pp_integral', 'mg C m^-2 day^-1', valid_pixel_expression)
         write_pixels_to_nc(dst, 'pp_integral', 0, 0, width, height, pp_data)
+        create_band(dst, 'kdpar', 'm^-1', valid_pixel_expression)
+        write_pixels_to_nc(dst, 'kdpar', 0, 0, width, height, kdpar_data)
 
     return output_file
-
-
-def PhytoplanktonToChlorophyll(ph):
-    # a_CHL = 0.054 CHL ** 0.96
-    return (ph / 0.054) ** (1/0.96)
-
-
-def pp_trapezoidal_numerical_integration(zvals, qpar0, Cchl, KdMorel):
-    if qpar0.shape == Cchl.shape and Cchl.shape == KdMorel.shape:
-        pp_tni = np.zeros_like(Cchl)
-        pp_tni[:] = np.nan
-        for i in range(1, pp_tni.shape[0] - 1):
-            if np.isfinite(Cchl[i]) and np.isfinite(qpar0[i]) and np.isfinite(KdMorel[i]) and Cchl[i] > 0:
-                pp_tni[i] = trapezoid(PP(zvals, qpar0[i], Cchl[i], KdMorel[i]), zvals)
-            else:
-                continue
-    else:
-        raise RuntimeWarning("Matrices are not of consistent shape")
-    return pp_tni
-
-
-def datetomonth(date):
-    return int(date[4:6])
-
-
-def qpar0_lookup(month, matrix):
-    lookup = {1: 2.5, 2: 2.5, 3: 4.0, 4: 4.0, 5: 6.5, 6: 6.5, 7: 6.5, 8: 6.5, 9: 4.0, 10: 4.0, 11: 2.5, 12: 2.5}
-    qpar0 = np.zeros_like(matrix)
-    try:
-        qpar_constant = lookup[month]
-    except KeyError:
-        qpar_constant = 6  # Default value
-    return qpar0 + qpar_constant
-
-
-def absorption(Cchl):
-    staehr = np.array([[405,415,425,435,445,455,465,475,485,495,505,515,525,535,545,555,565,575,585,595,605,615,625,635,645,655,665,675,685,695],
-    [0.0354096166,0.0421678948,0.0473295299,0.0518112242,0.0528416913,0.0492712169,0.0468541233,0.0438758593,0.0396055613,0.0344464397,0.0279767283,0.0218711903,0.0174634833,0.0144184829,0.0120222884,0.0099181185,0.0082114226,0.007502871,0.0076737813,0.0079705761,0.0079189265,0.0082036874,0.0091286864,0.010055497,0.0109449428,0.0124636724,0.0179222053,0.0238667838,0.0187654866,0.0081258648],
-    [0.23925,0.25175,0.2665,0.27725,0.28625,0.29725,0.297,0.30275,0.30675,0.28,0.23575,0.19325,0.1535,0.123,0.104,0.099,0.1115,0.1205,0.1495,0.17375,0.188,0.16625,0.1715,0.18575,0.202,0.21875,0.21175,0.18075,0.13575,0.1185]])
-    return staehr[1,:]*(Cchl**(1-staehr[2,:]))  # Should the 1 be removed?
-
-
-def q0par(z, qpar0, Cchl, Kpar):
-    C1 = 1.32*Kpar**0.153
-    C2 = 0.0023*Cchl + 0.016
-    return C1*np.exp(C2*z) * 0.94*qpar0*np.exp(-Kpar*z)
-
-
-def Qstarpar(z, q0par, Cchl):
-    return q0par*np.average(absorption(Cchl))
-
-
-def M (qpar0, Cchl, Kpar):
-    if Cchl < 35:
-        return 3.18-0.2125*Kpar**2.5+0.34*qpar0
-    if Cchl < 80:
-        return 3.58-0.31*qpar0-0.0072*Cchl
-    if Cchl < 120:
-        return 2.46 - 0.106*qpar0 - 0.00083*Cchl**1.5
-    else:
-        return 0.67
-
-
-def Fpar(z, q0par, M):
-    Fmax = 0.08
-    return Fmax/(1+M*q0par)**1.5
-
-
-def PP(z, qpar0, Cchl, Kpar):
-    Mval = M(qpar0, Cchl, Kpar)
-    rad = q0par(z, qpar0, Cchl, Kpar)
-    return 12000*Fpar(z, rad, Mval)*Qstarpar(z, rad, Cchl)

--- a/processors/secchidepth/secchidepth.py
+++ b/processors/secchidepth/secchidepth.py
@@ -134,8 +134,8 @@ def process(env, params, l1product_path, l2product_files, out_path):
 
             secchi_band_names = ['Z' + band_name[2:] for band_name in spectral_band_names] + [a_gelb_band] + \
                                 ['a_dg' + band_name[2:] for band_name in spectral_band_names] + \
-                                ['a_ph' + band_name[2:] for band_name in spectral_band_names] + ['Zsd_lee', 'Zsd_jiang']
-            secchi_band_units = ['m' if 'Z' in bn else ('m^-1' if 'a' in bn else None) for bn in secchi_band_names]
+                                ['a_ph' + band_name[2:] for band_name in spectral_band_names] + ['Zsd_lee', 'Zsd_jiang', 'Kd490']
+            secchi_band_units = ['m' if 'Z' in bn else ('m^-1' if ('a' in bn or 'Kd' in bn) else None) for bn in secchi_band_names]
 
             valid_pixel_expression = get_valid_pe_from_nc(src)
             inclusions = []
@@ -212,7 +212,7 @@ def secchi_s2(width, rs, rrs, us, sza, aws, bws, wvl, m0, m1, m2, m3, y1):
     usa = np.array(us)
     Kda[Kda < 0] = np.nan
     non_nan_rows = np.any(Kda > 0, axis=0)
-    if np.any(non_nan_rows is True):
+    if np.any(non_nan_rows == True):
         minKd_ind = np.nanargmin(Kda[:, non_nan_rows], axis=0)
 
         # Zsd(broadband) according to Lee et al. (2015)
@@ -232,15 +232,14 @@ def secchi_s2(width, rs, rrs, us, sza, aws, bws, wvl, m0, m1, m2, m3, y1):
     s = 0.015 + (0.002 / (0.6 + ratio))
     xi = np.exp(s * (442.5 - 412.5))
     # gelbstoff and detritus for 442.5 nm:
+    # TODO: S2 has no 412 band, using index 0 (443) for both — verify decomposition is valid
     a_g = ((a_s[0] - (zeta * a_s[0])) / (xi - zeta)) - ((aws[0] - (zeta * aws[0])) / (xi - zeta))
     # a_g for whole spectrum:
     a_g_s = [a_g * np.exp(-s * (wv - 442.5)) for wv in wvl]
     # phytoplancton pigments:
     a_ph = [a - aw - a_g_s for (a, a_g_s, aw) in zip(a_s, a_g_s, aws)]
     Zs.append(a_g)
-    rrs.append(Zsd_lee)
-    rrs.append(Zsd_jiang)
-    output = Zs + a_ph + rrs
+    output = Zs + a_g_s + a_ph + [Zsd_lee, Zsd_jiang, Kds[1]]
 
     # Mark infinite values as NAN
     for bds in output:
@@ -309,9 +308,7 @@ def secchi_s3(width, rs, rrs, us, sza, aws, bws, wvl, m0, m1, m2, m3, y1):
     # phytoplancton pigments:
     a_ph = [a - aw - a_g_s for (a, a_g_s, aw) in zip(a_s, a_g_s, aws)]
     Zs.append(a_g)
-    rrs.append(Zsd_lee)
-    rrs.append(Zsd_jiang)
-    output = Zs + a_ph + rrs
+    output = Zs + a_g_s + a_ph + [Zsd_lee, Zsd_jiang, Kds[2]]
 
     # Mark infinite values as NAN
     for bds in output:


### PR DESCRIPTION
Fixes band name/data alignment in secchidepth output. Missing a_g_s caused a_dg and a_ph bands to contain wrong data. Also adds Kd490 as an output band.

Replaces the Arst primary production model with Lee quantum yield using spectrally resolved PAR and aph from Staehr & Markager 2004, derived from Chl only. PP now reads Kd490 from secchidepth instead of Zsd_lee, and gets hourly PAR from ERA5.